### PR TITLE
Add shadowing of MPFR functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,21 @@ julia> c = with_rounding(BigFloat, RoundUp) do
 
 ```
 
+Version 0.2 of `CRlibm` wraps the MPFR functions with the same extended syntax with rounding modes, so that we can do
+```julia
+julia> set_bigfloat_precision(64)
+64
+
+julia> exp(BigFloat(0.51), RoundDown)
+1.66529119494588632316
+
+julia> exp(BigFloat(0.51), RoundUp)
+1.66529119494588632327
+```
+
+The function `CRlibm.shadow_MPFR()` can be called to redefine the functions that take floating-point arguments to also use the MPFR versions. This is done automatically if the `CRlibm` library is not available.
+
+
 ## Author
 - [David P. Sanders](http://sistemas.fciencias.unam.mx/~dsanders),
 Departamento de Física, Facultad de Ciencias, Universidad Nacional Autónoma de México (UNAM)

--- a/src/CRlibm.jl
+++ b/src/CRlibm.jl
@@ -67,9 +67,7 @@ function wrap_MPFR()
 
             @eval function $(f)(x::BigFloat, $mode1)
                 with_rounding(BigFloat, $mode2) do
-                    with_bigfloat_precision(precision(x)) do
-                        $(f)(x)
-                    end
+                    $(f)(x)
                 end
             end
 

--- a/src/CRlibm.jl
+++ b/src/CRlibm.jl
@@ -5,11 +5,16 @@ unixpath = "../deps/src/crlibm-1.0beta4/libcrlibm"
 const libcrlibm = joinpath(dirname(@__FILE__), unixpath)
 
 # check from Diercxk.jl (3-clause BSD license):
+
+use_MPFR = false
+
 function __init__()
     # Ensure library is available.
     if (Libdl.dlopen_e(libcrlibm) == C_NULL)
-        error("CRlibm not properly installed. Run Pkg.build(\"CRlibm\")")
+        warn("CRlibm not properly installed. Try running Pkg.build(\"CRlibm\") to fix it. Falling back to use MPFR. Note that Windows is not yet supported.")
     end
+
+    use_MPFR = true
 end
 
 export tanpi, atanpi
@@ -31,60 +36,109 @@ function_list = [symbol(f) for f in function_list]
 # Aiming for functions of the form
 # cos(x::Float64, ::RoundingMode{:RoundUp}) = ccall((:cos, libcrlibm), Float64, (Float64,), x)
 
-for f in function_list
 
-    if f ∉ (:tanpi, :atanpi)  # these are not in Base
-        @eval import Base.$f
-    end
+function wrap_MPFR()
 
-    for (mode, symb) in [(:Nearest, "n"), (:Up, "u"), (:Down, "d"),
-                         (:ToZero, "z")
-                        ]
+    MPFR_function_list = split("exp expm1 log log1p log2 log10 "
+                        * "sin cos tan asin acos atan "
+                        * "sinh cosh")
 
-        fname = string(f, "_r", symb)
+    MPFR_function_list = [symbol(f) for f in function_list]
 
-        mode = Expr(:quote, mode)
-        mode = :(::RoundingMode{$mode})
+    ## Generate versions of functions for MPFR until included in Base
 
-        @eval ($f)(x::Float64, $mode) = ccall(($fname, libcrlibm), Float64, (Float64,), x)
-    end
-end
+    for f in MPFR_function_list
 
-
-# MPFR functions:
-
-MPFR_function_list = split("exp expm1 log log1p log2 log10 "
-                    * "sin cos tan asin acos atan "
-                    * "sinh cosh")
-
-MPFR_function_list = [symbol(f) for f in function_list]
-
-## Generate versions of functions for MPFR until included in Base
-
-for f in MPFR_function_list
-
-    for (mode, symb) in [(:Nearest, "n"), (:Up, "u"), (:Down, "d"),
-                         (:ToZero, "z")
-                         ]
-
-        fname = string(f, "_r", symb)
-
-        mode1 = Expr(:quote, mode)
-        mode1 = :(::RoundingMode{$mode1})
-
-        mode_string = string("Round", mode)
-        mode2 = symbol(mode_string)
-
-        @eval function $(f)(x::BigFloat, $mode1)
-            with_rounding(BigFloat, $mode2) do
-                with_bigfloat_precision(precision(x)) do
-                    $(f)(x)
-                end
-            end
+        if f ∉ (:tanpi, :atanpi)  # these are not in Base
+            @eval import Base.$f
         end
 
+        for (mode, symb) in [(:Nearest, "n"), (:Up, "u"), (:Down, "d"),
+                             (:ToZero, "z")
+                             ]
+
+            fname = string(f, "_r", symb)
+
+            mode1 = Expr(:quote, mode)
+            mode1 = :(::RoundingMode{$mode1})
+
+            mode_string = string("Round", mode)
+            mode2 = symbol(mode_string)
+
+            @eval function $(f)(x::BigFloat, $mode1)
+                with_rounding(BigFloat, $mode2) do
+                    with_bigfloat_precision(precision(x)) do
+                        $(f)(x)
+                    end
+                end
+            end
+
+        end
+    end
+
+end
+
+function wrap_CRlibm()
+    for f in function_list
+
+        if f ∉ (:tanpi, :atanpi)  # these are not in Base
+            @eval import Base.$f
+        end
+
+        for (mode, symb) in [(:Nearest, "n"), (:Up, "u"), (:Down, "d"),
+                             (:ToZero, "z")
+                            ]
+
+            fname = string(f, "_r", symb)
+
+            mode = Expr(:quote, mode)
+            mode = :(::RoundingMode{$mode})
+
+            @eval ($f)(x::Float64, $mode) = ccall(($fname, libcrlibm), Float64, (Float64,), x)
+        end
     end
 end
+
+function big53(x::Float64)
+    with_bigfloat_precision(53) do
+        BigFloat(x)
+    end
+end
+
+function shadow_MPFR()
+    for f in function_list
+
+        if f ∉ (:sinpi, :cospi, :tanpi, :atanpi)  # these are not in Base
+            @eval import Base.$f
+        end
+
+        for (mode, symb) in [(:Nearest, "n"), (:Up, "u"), (:Down, "d"),
+                             (:ToZero, "z")
+                            ]
+
+            fname = string(f, "_r", symb)
+
+            mode1 = Expr(:quote, mode)
+            mode1 = :(::RoundingMode{$mode1})
+
+            mode2 = symbol("Round", string(mode))
+
+            @eval ($f)(x::Float64, $mode1) = Float64(($f)(big53(x), $mode2))
+
+        end
+    end
+end
+
+
+
+wrap_MPFR()
+
+if !use_MPFR
+    wrap_CRlibm()
+else
+    shadow_MPFR()
+end
+
 
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,13 +21,14 @@ is_log(f) = string(f)[1:3] == "log"
 for f in CRlibm.function_list
     println("Testing CRlibm.$f")
 
+    ff = eval(f)  # the actual Julia function
+
     for val in (0.51, 103.2, -17.1, -0.00005)
         #print(val, " ")
 
         val <= 0.0 && is_log(f) && continue
         abs(val) > 1 && f ∈ (:asin, :acos) && continue
 
-        ff = eval(f)  # the actual Julia function
 
         a = ff(val, RoundDown)
         b = ff(val, RoundUp)
@@ -38,13 +39,12 @@ for f in CRlibm.function_list
         end
 
         for prec in (20, 100, 1000)
-            @show prec, val
+
             with_bigfloat_precision(prec) do
                 val = BigFloat(val)
                 a = ff(val, RoundDown)
                 b = ff(val, RoundUp)
 
-                @show a, b
                 @test b - a == my_eps(a) || b - a == my_eps(b)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ function test_CRlibm(function_list)
 
         for val in (0.51, 103.2, -17.1, -0.00005)
 
-            @show f, val
+            #@show f, val
 
             val <= 0.0 && is_log(f) && continue
             abs(val) > 1 && f ∈ (:asin, :acos) && continue
@@ -52,7 +52,7 @@ function test_MPFR()
         for val in (0.51, 103.2, -17.1, -0.00005)
             #print(val, " ")
 
-            @show f, val
+            #@show f, val
 
             val <= 0.0 && is_log(f) && continue
             abs(val) > 1 && f ∈ (:asin, :acos) && continue

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,9 +73,11 @@ end
 
 println("Testing CRlibm")
 test_CRlibm(CRlibm.function_list)
-CRlibm.shadow_MPFR()
+# This will currently fail on the :sinpi etc. functions (that are not defined in MPFR) if MPFR is already enabled because the CRlibm library could not be found
+
 
 println("Testing shadowing MPFR")
+CRlibm.shadow_MPFR()
 test_CRlibm(CRlibm.MPFR_function_list)
 
 println("Testing MPFR")


### PR DESCRIPTION
By choice using `CRlibm.shadow_MPFR()` or automatically if shared library fails to build.
