### PR TITLE
Workaround: download source code from Internet Archive snapshot

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -20,7 +20,8 @@ lib_name = "crlibm-1.0beta4"
 src_dir = "src"
 cd(src_dir)
 
-file = "http://lipforge.ens-lyon.fr/frs/download.php/162/$(lib_name).tar.gz"
+#the LipForge page has vanished, so use an Internet Archive snapshot as a *temporary* workaround
+file = "https://web.archive.org/web/20160413012118/http://lipforge.ens-lyon.fr/frs/download.php/162/$(lib_name).tar.gz"
 
 println("Downloading the library files from $file")
 println("Working in ", pwd())


### PR DESCRIPTION
The the LipForge page this script tries to download the CRlibm source from has vanished, making it impossible to install the package. Fortunately, the Internet Archive has a snapshot of the source code; I've pointed the download link there as a _temporary_ workaround.

Although there may be licensing subtleties I'm not aware of, it seems to me that CRlibm's GPL 2.0 license allows the Internet Archive, like anyone else, to distribute copies of the source code.
