### PR TITLE
Add support for Float32 and Float16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ os:
   - osx
 
 julia:
-  - 0.7
   - 1.0
+  - 1.3
   - nightly
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ julia:
   - 1.0
   - nightly
 
+matrix:
+  allow_failures:
+    - julia: nightly
+
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,11 @@ platform:
   - x86 # 32-bit
   - x64 # 64-bit
 
-# # Uncomment the following lines to allow failures on nightly julia
-# # (tests will run but not make your overall status red)
-# matrix:
-#   allow_failures:
-#   - julia_version: nightly
+# Uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - julia_version: nightly
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1
+  - julia_version: 1.3
   - julia_version: nightly
 
 platform:

--- a/src/CRlibm.jl
+++ b/src/CRlibm.jl
@@ -133,7 +133,7 @@ function wrap_generic_fallbacks()
 
         # Specialise for Float32 and Float16 to get the other IEEE FP types
         # working transparently as well
-        @eval $f(x::Float16, r::RoundingMode) = Float16((Base.$f)(Float32(x)), r)
+        @eval $f(x::Float16, r::RoundingMode) = Float16((Base.$f)(Float64(x)), r)
         @eval $f(x::Float32, r::RoundingMode) = Float32((Base.$f)(Float64(x)), r)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,29 @@
 using CRlibm
 using Test
 
+# Float64
 @test CRlibm.cos(0.5, RoundDown) == 0.8775825618903726
 @test CRlibm.cos(0.5, RoundUp) == 0.8775825618903728
 @test CRlibm.cos(0.5, RoundNearest) == cos(0.5) == 0.8775825618903728
 @test CRlibm.cos(1.6, RoundToZero) == -0.029199522301288812
 @test CRlibm.cos(1.6, RoundDown) == -0.029199522301288815
 @test CRlibm.cos(0.5) == CRlibm.cos(0.5, RoundNearest)
+
+# Float32
+@test CRlibm.cos(0.5f0, RoundDown) == 0.87758255f0
+@test CRlibm.cos(0.5f0, RoundUp) == 0.8775826f0
+@test CRlibm.cos(0.5f0, RoundNearest) == cos(0.5f0) == 0.87758255f0
+@test CRlibm.cos(1.6f0, RoundToZero) == -0.029199544f0
+@test CRlibm.cos(1.6f0, RoundDown) == -0.029199546f0
+@test CRlibm.cos(0.5f0) == CRlibm.cos(0.5f0, RoundNearest)
+
+# Float16
+@test CRlibm.cos(Float16(0.5), RoundDown) == Float16(0.8774)
+@test CRlibm.cos(Float16(0.5), RoundUp) == Float16(0.878)
+@test CRlibm.cos(Float16(0.5), RoundNearest) == cos(Float16(0.5)) == Float16(0.8774)
+@test CRlibm.cos(Float16(1.6), RoundToZero) == Float16(-0.02881)
+@test CRlibm.cos(Float16(1.6), RoundDown) == Float16(-0.02882)
+@test CRlibm.cos(Float16(0.5)) == CRlibm.cos(Float16(0.5), RoundNearest)
 
 function my_eps(prec::Int)
     ldexp(eps(Float64), 53-prec)


### PR DESCRIPTION
This PR adds transparent support for Float32 and Float16 datatypes. Closes #32.

- I experimented a bit with timings. The differences between using MPFR and doing the computation in the respective larger IEEE type and than rounding the result are very small. Happy to discuss alternative solutions.
- I also did some small cleanup (removed duplicate definitions, some tabs)