### PR TITLE
Use MPFR on 32 bit systems

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CRlibm"
 uuid = "96374032-68de-5a5b-8d9e-752f78720389"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 CRlibm_jll = "4e9b3aee-d8a1-5a3d-ad8b-7d824db253f0"

--- a/src/CRlibm.jl
+++ b/src/CRlibm.jl
@@ -156,6 +156,9 @@ const MPFR_function_names = split("""exp expm1 log log1p log2 log10
 
 const MPFR_functions = map(Symbol, MPFR_function_names)
 
-use_MPFR = setup()
+# The underlying crlibm tests fail on 32 bit build - just use MPFR there (see #45)
+is_32_bit = Int == Int32
+
+use_MPFR = setup(is_32_bit)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,9 @@ using Test
 @test CRlibm.cos(Float16(1.6), RoundDown) == Float16(-0.02882)
 @test CRlibm.cos(Float16(0.5)) == CRlibm.cos(Float16(0.5), RoundNearest)
 
+# One failing example from #45
+@test CRlibm.log10(10.0, RoundUp) == 1.0
+
 function my_eps(prec::Int)
     ldexp(eps(Float64), 53-prec)
 end


### PR DESCRIPTION
It seems the existing crlibm binaries are broken on 32 bit, as they
don't pass crlibm's own tests. Therefore, just fall back to MPFR on
these systems for safety.

This is a minimal workaround for #45 